### PR TITLE
change to using derived_from_or_self() to fix yanglint warnings

### DIFF
--- a/ietf-layer0-types.yang
+++ b/ietf-layer0-types.yang
@@ -262,7 +262,9 @@ module ietf-layer0-types {
         "Label for DWDM or CWDM grid";
       case dwdm {
         leaf dwdm-n {
-          when "../../../grid-type = 'wson-grid-dwdm'" {
+          when 'derived-from-or-self(../../../grid-type,
+          "wson-grid-dwdm")'
+          {
             description
               "Valid only when grid type is DWDM.";
           }
@@ -276,7 +278,9 @@ module ietf-layer0-types {
       }
       case cwdm {
         leaf cwdm-n {
-          when "../../../grid-type = 'wson-grid-cwdm'" {
+          when 'derived-from-or-self(../../../grid-type,
+          "wson-grid-cwdm")'
+          {
             description
               "Valid only when grid type is CWDM.";
           }
@@ -372,7 +376,9 @@ module ietf-layer0-types {
         "Grid type: DWDM, CWDM, etc.";
       case dwdm {
         leaf wson-dwdm-channel-spacing {
-          when "../../grid-type = 'wson-grid-dwdm'" {
+          when 'derived-from-or-self(../../grid-type,
+          "wson-grid-dwdm")'
+          {
             description
               "Valid only when grid type is DWDM.";
           }
@@ -389,7 +395,9 @@ module ietf-layer0-types {
       }
       case cwdm {
         leaf wson-cwdm-channel-spacing {
-          when "../../grid-type = 'wson-grid-cwdm'" {
+          when 'derived-from-or-self(../../grid-type,
+          "wson-grid-cwdm")'
+          {
             description
               "Valid only when grid type is CWDM.";
           }


### PR DESCRIPTION
This change is to resolve the yanglint warning in ietf-wson-topology. It suggests to use derived-from-or-self(). 